### PR TITLE
crash on resize fix

### DIFF
--- a/todoism/main.py
+++ b/todoism/main.py
@@ -152,7 +152,7 @@ def main(stdscr):
             if task_cnt >= window_height - 1:
                 stdscr.erase()
                 pr.print_main_view(stdscr, len(done_list), len(task_list), task_list, current_id, start, end - 1)
-            stdscr.addstr(curses.LINES - 1, 0, ":")
+            stdscr.addstr(window_height - 1, 0, ":")
             stdscr.refresh()
             command_line = stdscr.getstr().decode('utf-8')
             curses.curs_set(0)


### PR DESCRIPTION
it fixes #1 because `LINES`/`COLS` variables are defined after `initscr()` is called, and updated by `update_lines_cols()`, `resizeterm()` and `resize_term()` [[1]](https://docs.python.org/3/library/curses.html#curses.LINES)