### PR TITLE
Message format fix

### DIFF
--- a/todoism/message.py
+++ b/todoism/message.py
@@ -376,19 +376,25 @@ UPDATE_FAILURE_MSG = '''
 def keycode_summary():
     """Constructs a message for the given keycode"""
     import todoism.keycode as kc
+    ctrl_left = f"CTRL + LEFT: {kc.CTRL_LEFT}"
+    ctrl_right = f"CTRL + RIGHT: {kc.CTRL_RIGHT}"
+    ctrl_s_left = f"CTRL + SHIFT + LEFT: {kc.CTRL_SHIFT_LEFT}"
+    ctrl_s_right = f"CTRL + SHIFT + RIGHT: {kc.CTRL_SHIFT_RIGHT}"
+    alt_left = f"ALT + LEFT: {kc.ALT_LEFT}"
+    alt_right = f"ALT + RIGHT: {kc.ALT_RIGHT}"
     msg =  f"""
     ┌───────────────────────────────────────────────┐
-    │   CTRL + LEFT: {kc.CTRL_LEFT}                            │
+    │   {ctrl_left:<44}│
     │                                               │
-    │   CTRL + RIGHT: {kc.CTRL_RIGHT}                           │
+    │   {ctrl_right:<44}│
     │                                               │
-    │   CTRL + SHIFT + LEFT: {kc.CTRL_SHIFT_LEFT}                    │
+    │   {ctrl_s_left:<44}│
     │                                               │
-    │   CTRL + SHIFT + RIGHT: {kc.CTRL_SHIFT_RIGHT}                   │
+    │   {ctrl_s_right:<44}│
     │                                               │
-    │   ALT + LEFT: {kc.ALT_LEFT}                             │
+    │   {alt_left:<44}│
     │                                               │
-    │   ALT + RIGHT: {kc.ALT_RIGHT}                            │
+    │   {alt_right:<44}│
     └───────────────────────────────────────────────┘
     """
     return msg


### PR DESCRIPTION
There broken frame in the `:keycode show` command due to the number length, so I aligned[^1] it with hardcoded width value based on blank lines (47-3).

![image](https://github.com/user-attachments/assets/b356514c-ef1e-4c86-8d47-b2d3bea5face)

This can still be done in the f-string itself like so:
```python
f"│   {f'CTRL + LEFT: {kc.CTRL_LEFT}':<44}│"
```
but nesting f-strings are relatively new and added in 3.12[^2]

[^1]: https://docs.python.org/3/library/string.html#format-specification-mini-language
[^2]: https://peps.python.org/pep-0701/